### PR TITLE
fix: space in logo URL in navbar

### DIFF
--- a/templates/home/components/navbar.html
+++ b/templates/home/components/navbar.html
@@ -6,7 +6,7 @@
             <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
                 <div class="container-fluid">
                     <a class="navbar-brand text-start" href="https://codeonion.net">
-                        <img src={%  static  'img/Code_Onion_White.png '%} alt="" height="30">
+                        <img src="{% static 'img/Code_Onion_White.png'%}" alt="Codeonion_Logo" height="30">
                         CodeOnion
                     </a>
                     <ul class="navbar-nav ms-auto">


### PR DESCRIPTION
The logo wasn't loaded since there's a space in the URL path
the request 
GET | https://pubcdn-test.codeonion.net/img/Code_Onion_White.png%20
failed with 403